### PR TITLE
Adds support to use libjli.dylib as -vm argument

### DIFF
--- a/net.resheim.eclipse.launcher.core/src-test/net/resheim/eclipse/launcher/core/LauncherPluginTest.java
+++ b/net.resheim.eclipse.launcher.core/src-test/net/resheim/eclipse/launcher/core/LauncherPluginTest.java
@@ -45,7 +45,10 @@ public class LauncherPluginTest extends LauncherPlugin {
 	private static final String ECLIPSE_VM_FULL = "/path/to/vm/Contents/Home/bin/java";
 
 	/** <full path to the virtual machine library> */
-	private static final String ECLIPSE_VM_FULL_LIB = "/path/to/vm/Contents/Home/jre/lib/server/libjvm.dylib";
+	private static final String ECLIPSE_VM_FULL_JVM_LIB = "/path/to/vm/Contents/Home/jre/lib/server/libjvm.dylib";
+
+	/** <full path to the launcher interface library> */
+	private static final String ECLIPSE_VM_FULL_JLI_LIB = "/path/to/vm/Contents/Home/jre/lib/server/libjli.dylib";
 
 	/** <full path to the virtual machine> */
 	private static final String ECLIPSE_VM_HOME = "/path/to/vm/Contents/Home";
@@ -170,12 +173,24 @@ public class LauncherPluginTest extends LauncherPlugin {
 		Assert.assertEquals("some", args.get(2));
 	}
 
-	public void testCommandLineDylibVM() {
+	@Test
+	public void testBuildCommandLineWithJVMDylib() {
 		LauncherPlugin.getDefault();
-		List<String> args = LauncherPlugin.buildCommandLine(null, ECLIPSE_COMMANDS, null, ECLIPSE_VM_FULL_LIB);
+		List<String> args = LauncherPlugin.buildCommandLine(null, ECLIPSE_COMMANDS, null, ECLIPSE_VM_FULL_JVM_LIB);
 		Assert.assertEquals(3, args.size());
 		Assert.assertEquals("-vm", args.get(0));
-		Assert.assertEquals(ECLIPSE_VM_FULL_LIB, args.get(1));
+		Assert.assertEquals(ECLIPSE_VM_FULL_JVM_LIB, args.get(1));
 		Assert.assertEquals(ECLIPSE_COMMANDS, args.get(2));
 	}
+
+	@Test
+	public void testBuildCommandLineWithJLIDylib() {
+		LauncherPlugin.getDefault();
+		List<String> args = LauncherPlugin.buildCommandLine(null, ECLIPSE_COMMANDS, null, ECLIPSE_VM_FULL_JLI_LIB);
+		Assert.assertEquals(3, args.size());
+		Assert.assertEquals("-vm", args.get(0));
+		Assert.assertEquals(ECLIPSE_VM_FULL_JLI_LIB, args.get(1));
+		Assert.assertEquals(ECLIPSE_COMMANDS, args.get(2));
+	}
+
 }

--- a/net.resheim.eclipse.launcher.core/src/net/resheim/eclipse/launcher/core/LauncherPlugin.java
+++ b/net.resheim.eclipse.launcher.core/src/net/resheim/eclipse/launcher/core/LauncherPlugin.java
@@ -149,7 +149,7 @@ public class LauncherPlugin extends AbstractUIPlugin {
 			if (!vm.startsWith(APPLE_JAVA)) {
 				if (vm.endsWith("Contents/Home")) { //$NON-NLS-1$
 					vm = vm + "/bin/java"; //$NON-NLS-1$
-				} else if (!vm.endsWith("java") && !vm.endsWith("libjvm.dylib")) { //$NON-NLS-1$ //$NON-NLS-2$
+				} else if (!vm.endsWith("java") && !vm.endsWith("libjvm.dylib") && !vm.endsWith("libjli.dylib")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 					vm = vm + "/Contents/Home/bin/java"; //$NON-NLS-1$
 				}
 			}


### PR DESCRIPTION
Adds support to use a path to the `libjli.dylib` as `-vm` argument.

In macOS the only way to use a JDK downloaded with SDKMAN (or any other JDK that does not have the macOS directory layout) is specifying the path to the `libjli.dylib` file, like:

```
-vm
/<PATH_TO_YOUR_JDK>/jre/lib/jli/libjli.dylib
```

Without this changes having a main Eclipse with a `-vm` pointing to a `libjli.dylib` works but trying to open a second instance using this plugin fails with this error:

<img width="424" alt="eclipse-launcher fails with a configured libjli.dylib" src="https://user-images.githubusercontent.com/1738654/78460935-9761d100-769b-11ea-9fe4-2ab7c08e957e.png">

For more information see:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=549813#c3